### PR TITLE
allow blog post title to be filtered

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -672,6 +672,8 @@ function shapely_top_callout() {
 								} else {
 									echo get_the_archive_title();
 								}
+							} elseif ( is_singular() ) {
+								echo single_post_title();								
 							} else {
 								echo get_the_title();
 							}


### PR DESCRIPTION
Blog singular should use `single_post_title()` to display its page title (heading). This allows it to be filtered as per WP docs:

https://developer.wordpress.org/reference/functions/single_post_title/

## Why?

I'm setting up a travel blog and wanted to prefix "DAY 123:" before all the blog posts to track the day of the journey. Using the filter `the_title` worked for almost everything except for the title block (`.page-title-section`) of the single posts:

```
// https://wordpress.stackexchange.com/questions/26115/how-to-correctly-get-post-type-in-a-the-title-filter/26782#26782
function prefix_the_title_with_day( $title, $id = null ) {

	global $id, $post;
	if ( $id && $post && $post->post_type == 'post' ) {
		$days_prefix = get_days_prefix($post->post_date);

		$title = $days_prefix . $title;
	}

    return $title;
}
add_filter( 'the_title', 'prefix_the_title_with_day', 10, 2 );
```

The code in `inc\extras.php` falls back to `get_the_title()` but the filter doesn't get applied for some reason. Digging into it further I found WP provides a specialised method for the `is_singular()` posts, `single_post_title()` which has its own filter `single_post_title`.

By adding the lines in the pull request I was then able to use that filter to add the prefix that I originally wanted:

```
function prefix_single_post_title_with_day ( $post_title, $post ) {

	$days_prefix = get_days_prefix($post->post_date);

	return $days_prefix . $post_title;

}
add_filter( 'single_post_title', 'prefix_single_post_title_with_day', 10, 2 );
```

FYI: This single_post_title() is also used in the meta title tag of the page by default in WP, so this filter 